### PR TITLE
Add unified ConfigManagerPlus namespace

### DIFF
--- a/ConfigManager+/Class1.cs
+++ b/ConfigManager+/Class1.cs
@@ -1,7 +1,7 @@
-﻿namespace ConfigManager_
+namespace ConfigManagerPlus;
+
+public class Class1
 {
-    public class Class1
-    {
         // ------------------- USAGE EXAMPLE (Console) -------------------
         // var cfg = new ConfigManagerPlus.ConfigManager()
         //     .AddJson("appsettings.json")
@@ -23,5 +23,4 @@
         // Console.WriteLine(cfg.Dump());
         //
         // Console.ReadKey();
-    }
 }

--- a/ConfigManager+/ConfigChangedEventArgs.cs
+++ b/ConfigManager+/ConfigChangedEventArgs.cs
@@ -1,4 +1,6 @@
-﻿public sealed class ConfigChangedEventArgs : EventArgs
+namespace ConfigManagerPlus;
+
+public sealed class ConfigChangedEventArgs : EventArgs
 {
     public IReadOnlyDictionary<string, string> Added { get; }
     public IReadOnlyDictionary<string, (string OldValue, string NewValue)> Modified { get; }
@@ -6,13 +8,12 @@
     public string? SourcePath { get; }
     public string? SourceName { get; }
 
-
     public ConfigChangedEventArgs(
-    IDictionary<string, string> added,
-    IDictionary<string, (string OldValue, string NewValue)> modified,
-    IList<string> removed,
-    string? sourcePath,
-    string? sourceName)
+        IDictionary<string, string> added,
+        IDictionary<string, (string OldValue, string NewValue)> modified,
+        IList<string> removed,
+        string? sourcePath,
+        string? sourceName)
     {
         Added = new Dictionary<string, string>(added);
         Modified = new Dictionary<string, (string, string)>(modified);
@@ -21,3 +22,4 @@
         SourceName = sourceName;
     }
 }
+

--- a/ConfigManager+/ConfigLayer.cs
+++ b/ConfigManager+/ConfigLayer.cs
@@ -1,4 +1,6 @@
-﻿/// <summary>
+namespace ConfigManagerPlus;
+
+/// <summary>
 /// Represents one configured source layer (file/env/args) with precedence and optional watcher.
 /// </summary>
 internal sealed class ConfigLayer
@@ -10,7 +12,6 @@ internal sealed class ConfigLayer
     public IDictionary<string, string> Data { get; set; }
     public bool IsDynamic { get; } // env/args
 
-
     public ConfigLayer(string path, IConfigProvider provider, int order, bool isDynamic, IDictionary<string, string> data)
     {
         Path = path;
@@ -20,3 +21,4 @@ internal sealed class ConfigLayer
         Data = data;
     }
 }
+

--- a/ConfigManager+/ConfigManager.cs
+++ b/ConfigManager+/ConfigManager.cs
@@ -1,6 +1,7 @@
-﻿using System.Text;
-
+using System.Text;
 using System.Text.Json;
+
+namespace ConfigManagerPlus;
 
 /// <summary>
 /// ConfigManager+ core. Compose providers as layers; last added wins.

--- a/ConfigManager+/EnvFileConfigProvider.cs
+++ b/ConfigManager+/EnvFileConfigProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+using System.Text;
+
+namespace ConfigManagerPlus;
 
 public sealed class EnvFileConfigProvider : IConfigProvider
 {

--- a/ConfigManager+/IConfigProvider.cs
+++ b/ConfigManager+/IConfigProvider.cs
@@ -1,4 +1,6 @@
-﻿/// <summary>
+namespace ConfigManagerPlus;
+
+/// <summary>
 /// Provider contract: loads a source file and returns flattened key-value pairs ("A:B:C" -> value).
 /// </summary>
 public interface IConfigProvider
@@ -7,3 +9,4 @@ public interface IConfigProvider
     IDictionary<string, string> Load(string path);
     bool SupportsHotReload { get; }
 }
+

--- a/ConfigManager+/IniConfigProvider.cs
+++ b/ConfigManager+/IniConfigProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+using System.Text;
+
+namespace ConfigManagerPlus;
 
 public sealed class IniConfigProvider : IConfigProvider
 {

--- a/ConfigManager+/JsonConfigProvider.cs
+++ b/ConfigManager+/JsonConfigProvider.cs
@@ -1,5 +1,7 @@
-﻿using System.Text;
+using System.Text;
 using System.Text.Json;
+
+namespace ConfigManagerPlus;
 
 public sealed class JsonConfigProvider : IConfigProvider
 {

--- a/ConfigManager+/PassthroughProvider.cs
+++ b/ConfigManager+/PassthroughProvider.cs
@@ -1,7 +1,10 @@
-﻿internal sealed class PassthroughProvider : IConfigProvider
+namespace ConfigManagerPlus;
+
+internal sealed class PassthroughProvider : IConfigProvider
 {
     public string SourceName { get; }
     public bool SupportsHotReload => false;
     public PassthroughProvider(string name) { SourceName = name; }
     public IDictionary<string, string> Load(string path) => throw new NotSupportedException();
 }
+

--- a/ConfigManager+/SectionView.cs
+++ b/ConfigManager+/SectionView.cs
@@ -1,10 +1,14 @@
-﻿public sealed class SectionView
+namespace ConfigManagerPlus;
+
+public sealed class SectionView
 {
     private readonly ConfigManager _mgr;
     private readonly string _prefix; // normalized ends with ':'
+
     internal SectionView(ConfigManager mgr, string prefix)
     {
-        _mgr = mgr; _prefix = prefix;
+        _mgr = mgr;
+        _prefix = prefix;
     }
 
     private string Key(string key) => string.Concat(_prefix, key);
@@ -22,3 +26,4 @@
     public T Bind<T>() where T : new() => _mgr.Bind<T>(_prefix.TrimEnd(':'));
     public override string ToString() => _prefix; // debug
 }
+

--- a/ConfigManager+/YamlConfigProvider.cs
+++ b/ConfigManager+/YamlConfigProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+using System.Text;
+
+namespace ConfigManagerPlus;
 
 public sealed class YamlConfigProvider : IConfigProvider
 {


### PR DESCRIPTION
## Summary
- add file-scoped `ConfigManagerPlus` namespace to all C# files
- tidy using directives and preserve intended access modifiers

## Testing
- `dotnet build ConfigManager+.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a1a20d6083279c75b982a6128bfa