### PR TITLE
Add demo console project for ConfigManagerPlus

### DIFF
--- a/ConfigManager+.sln
+++ b/ConfigManager+.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36414.22 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigManager+", "ConfigManager+\ConfigManager+.csproj", "{0001ACAF-EFCD-41FA-8BEF-A492E241C30E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo", "Demo\Demo.csproj", "{A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
@@ -20,6 +22,10 @@ Global
 		{0001ACAF-EFCD-41FA-8BEF-A492E241C30E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0001ACAF-EFCD-41FA-8BEF-A492E241C30E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0001ACAF-EFCD-41FA-8BEF-A492E241C30E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ConfigManager+.sln
+++ b/ConfigManager+.sln
@@ -22,10 +22,10 @@ Global
 		{0001ACAF-EFCD-41FA-8BEF-A492E241C30E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0001ACAF-EFCD-41FA-8BEF-A492E241C30E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0001ACAF-EFCD-41FA-8BEF-A492E241C30E}.Release|Any CPU.Build.0 = Release|Any CPU
-                {A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9AF9D99-3DA6-4BB6-9BF1-D672456BC4FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Demo/.env
+++ b/Demo/.env
@@ -1,0 +1,3 @@
+APP__Server__Port=6000
+APP__Server__Debug=false
+APP__Database__ConnectionString=env-connection

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ConfigManager+\ConfigManager+.csproj" />
+    <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="config.yaml" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="settings.ini" CopyToOutputDirectory="PreserveNewest" />
+    <None Include=".env" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -1,0 +1,41 @@
+using ConfigManagerPlus;
+
+// Build configuration from multiple sources
+var cfg = new ConfigManager()
+    .AddJson("appsettings.json", optional: true, reloadOnChange: true)
+    .AddYaml("config.yaml", optional: true, reloadOnChange: true)
+    .AddIni("settings.ini", optional: true, reloadOnChange: true)
+    .AddEnvFile(".env", optional: true, reloadOnChange: true)
+    .AddEnvironmentVariables("APP__")
+    .AddCommandLine(args);
+
+// Subscribe to change events
+cfg.Changed += (s, e) =>
+    Console.WriteLine($"Config changed from {e.SourceName}:{e.SourcePath}");
+
+// Ensure critical keys exist
+cfg.Require("Server:Port", "Database:ConnectionString");
+
+// Typed getters
+int port = cfg.GetInt("Server:Port", 8080);
+bool debug = cfg.GetBool("Server:Debug", false);
+
+// Section access and binding
+var dbSettings = cfg.Section("Database").Bind<DatabaseSettings>();
+
+Console.WriteLine($"Port: {port}");
+Console.WriteLine($"Debug: {debug}");
+Console.WriteLine($"Connection: {dbSettings.ConnectionString}");
+
+Console.WriteLine();
+Console.WriteLine("Dump of current configuration:");
+Console.WriteLine(cfg.Dump());
+
+Console.WriteLine();
+Console.WriteLine("Modify any config file and save to see hot reload in action. Press Enter to exit.");
+Console.ReadLine();
+
+public class DatabaseSettings
+{
+    public string ConnectionString { get; set; } = string.Empty;
+}

--- a/Demo/README.md
+++ b/Demo/README.md
@@ -1,0 +1,11 @@
+# ConfigManagerPlus Demo
+
+This console application demonstrates how to use **ConfigManagerPlus** with JSON, YAML, INI and `.env` files, environment variables and command-line overrides. It also shows hot reload, typed getters, validation and section binding.
+
+Run the demo (once the .NET SDK is installed) with:
+
+```
+dotnet run --project Demo
+```
+
+Edit any of the configuration files while the app is running to see hot reload in action.

--- a/Demo/appsettings.json
+++ b/Demo/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Server": {
+    "Port": 5000,
+    "Debug": true
+  },
+  "Database": {
+    "ConnectionString": "Server=.;Database=App;Trusted_Connection=True;"
+  }
+}

--- a/Demo/config.yaml
+++ b/Demo/config.yaml
@@ -1,0 +1,4 @@
+Server:
+  Port: 5001
+Database:
+  ConnectionString: yaml-connection

--- a/Demo/settings.ini
+++ b/Demo/settings.ini
@@ -1,0 +1,5 @@
+[Server]
+Port=5002
+
+[Database]
+ConnectionString=ini-connection


### PR DESCRIPTION
## Summary
- add demo console app showcasing ConfigManagerPlus features and hot reload
- include sample configuration files
- update solution to reference demo project

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c53ba58c54832782d9cc30987d9afa